### PR TITLE
Support overriding charset

### DIFF
--- a/src/main/java/no/ssb/crypto/tink/fpe/FpeFf3.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/FpeFf3.java
@@ -105,7 +105,7 @@ public final class FpeFf3 implements Fpe {
         }
 
         String tweak = hexTweakOf(params.getTweak());
-        String pt = b2s(plaintext);
+        String pt = b2s(plaintext, params.getCharset());
 
         CharacterSkipper charSkipper = null;
         if (params.getUnknownCharacterStrategy() == UnknownCharacterStrategy.SKIP) {
@@ -137,7 +137,7 @@ public final class FpeFf3 implements Fpe {
             charSkipper.injectSkippedInto(ciphertext);
         }
 
-        return s2b(ciphertext.toString());
+        return s2b(ciphertext.toString(), params.getCharset());
     }
 
     /**
@@ -157,7 +157,7 @@ public final class FpeFf3 implements Fpe {
         }
 
         String tweak = hexTweakOf(params.getTweak());
-        String ct = b2s(ciphertext);
+        String ct = b2s(ciphertext, params.getCharset());
         CharacterSkipper charSkipper = null;
 
         if (params.getUnknownCharacterStrategy() == UnknownCharacterStrategy.SKIP) {
@@ -177,7 +177,7 @@ public final class FpeFf3 implements Fpe {
             charSkipper.injectSkippedInto(plaintext);
         }
 
-        return s2b(plaintext.toString());
+        return s2b(plaintext.toString(), params.getCharset());
     }
 
     // TODO: Unit test

--- a/src/main/java/no/ssb/crypto/tink/fpe/FpeParams.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/FpeParams.java
@@ -4,6 +4,9 @@ package no.ssb.crypto.tink.fpe;
 import lombok.*;
 import no.ssb.crypto.tink.fpe.util.ByteArrayUtil;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 /**
  * FpeParams is used as an argument when invoking encrypt and decrypt functions. It allows the user to specify
  * additional details such as how to handle unknown characters, using a custom tweak, etc.
@@ -49,6 +52,13 @@ public class FpeParams {
     private Character redactionChar = null;
 
     /**
+     * charset is the character set the underlying implementation expects when working with Strings.
+     *
+     * Defaults to UTF-8, but can be overridden if e.g. the plaintext is encoded differently.
+     */
+    private Charset charset = StandardCharsets.UTF_8;
+
+    /**
      * unknownCharacterStrategy defines the strategy for how the encryption/decryption process should handle characters
      * that are not in the FPE alphabet.
      */
@@ -75,6 +85,16 @@ public class FpeParams {
      */
     public FpeParams redactionChar(char redactionChar) {
         this.redactionChar = redactionChar;
+        return this;
+    }
+
+    /**
+     * charset is the character set the underlying implementation expects when working with Strings.
+     *
+     * Defaults to UTF-8, but can be overridden if e.g. the plaintext is encoded differently.
+     */
+    public FpeParams charset(Charset charset) {
+        this.charset = charset;
         return this;
     }
 

--- a/src/main/java/no/ssb/crypto/tink/fpe/util/ByteArrayUtil.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/util/ByteArrayUtil.java
@@ -2,6 +2,7 @@ package no.ssb.crypto.tink.fpe.util;
 
 import lombok.experimental.UtilityClass;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -50,18 +51,26 @@ public class ByteArrayUtil {
     }
 
     public static String b2s(byte[] bArr) {
+        return b2s(bArr, StandardCharsets.UTF_8);
+    }
+
+    public static String b2s(byte[] bArr, Charset charset) {
         if (bArr == null || bArr.length == 0) {
             return null;
         }
 
-        return new String(bArr, StandardCharsets.UTF_8);
+        return new String(bArr, charset);
     }
 
     public static byte[] s2b(String s) {
+        return s2b(s, StandardCharsets.UTF_8);
+    }
+
+    public static byte[] s2b(String s, Charset charset) {
         if (s == null || s.length() == 0) {
             return null;
         }
-        return s.getBytes(StandardCharsets.UTF_8);
+        return s.getBytes(charset);
     }
 
 }

--- a/src/test/java/no/ssb/crypto/tink/fpe/FpeFf3Test.java
+++ b/src/test/java/no/ssb/crypto/tink/fpe/FpeFf3Test.java
@@ -182,13 +182,14 @@ public class FpeFf3Test {
         byte[] latin1Plaintext = plaintextStr.getBytes(StandardCharsets.ISO_8859_1);
         byte[] latin1Ciphertext = fpe.encrypt(latin1Plaintext, paramsLatin1);
         byte[] latin1PlaintextRestored = fpe.decrypt(latin1Ciphertext, paramsLatin1);
-        assertThat(latin1Plaintext).isEqualTo(latin1PlaintextRestored);
-
-        // Ensure the original and restored plaintexts match, regardless of the encoding used.
-        assertThat(utf8PlaintextRestored).isEqualTo(utf8PlaintextRestored);
+        assertThat(latin1PlaintextRestored).isEqualTo(latin1Plaintext);
 
         // Ciphertexts will be different if using different encodings
         assertThat(utf8Ciphertext).isNotEqualTo(latin1Ciphertext);
+
+        // Ensure the original and restored plaintexts match, regardless of the encoding used.
+        assertThat(plaintextStr).isEqualTo(new String(utf8PlaintextRestored, StandardCharsets.UTF_8));
+        assertThat(plaintextStr).isEqualTo(new String(latin1PlaintextRestored, StandardCharsets.ISO_8859_1));
     }
 
 }


### PR DESCRIPTION
Until now, the underlying implementation has assumed UTF-8 and used that internally when converting byte[] to String (Mysto FPE expects strings). If, for whatever reason, the user HAS TO use another encoding, using UTF-8 internally had the unfortunate effect of transforming the plaintext, typically resulting in non-compliant ciphertexts (e. g. with increased size), and no option to go back to the original plaintext.

By allowing the user to override the charset to apply before dispatching to Mysto FPE, we can get around this and guarantee that the original and restored plaintexts are the same, regardless of string encoding. However, the ciphertexts will be different.

The moral is: USE UTF-8 (!)