### PR TITLE
Rearrange alphanumeric alphabet

### DIFF
--- a/src/main/java/no/ssb/crypto/tink/fpe/FpeFfxKeyManager.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/FpeFfxKeyManager.java
@@ -12,7 +12,10 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.InvalidProtocolBufferException;
 import no.ssb.crypto.tink.fpe.text.CharacterGroup;
-import no.ssb.crypto.tink.proto.*;
+import no.ssb.crypto.tink.proto.FfxMode;
+import no.ssb.crypto.tink.proto.FpeFfxKey;
+import no.ssb.crypto.tink.proto.FpeFfxKeyFormat;
+import no.ssb.crypto.tink.proto.FpeFfxKeyParams;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/no/ssb/crypto/tink/fpe/FpeFfxKeyType.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/FpeFfxKeyType.java
@@ -8,17 +8,17 @@ import static no.ssb.crypto.tink.proto.FfxMode.FF31;
 public enum FpeFfxKeyType {
 
     /**
-     * FF3-1 (256 bits) key with alphanumeric alphabet (ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789)
+     * FF3-1 (256 bits) key with alphanumeric alphabet (0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz)
      */
     FPE_FF31_256_ALPHANUMERIC(FF31, 256, CharacterGroup.ALPHANUMERIC),
 
     /**
-     * FF3-1 (192 bits) key with alphanumeric alphabet (ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789)
+     * FF3-1 (192 bits) key with alphanumeric alphabet (0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz)
      */
     FPE_FF31_192_ALPHANUMERIC(FF31, 192, CharacterGroup.ALPHANUMERIC),
 
     /**
-     * FF3-1 (128 bits) key with alphanumeric alphabet (ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789)
+     * FF3-1 (128 bits) key with alphanumeric alphabet (0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz)
      */
     FPE_FF31_128_ALPHANUMERIC(FF31, 128, CharacterGroup.ALPHANUMERIC),
 

--- a/src/main/java/no/ssb/crypto/tink/fpe/FpeParams.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/FpeParams.java
@@ -1,7 +1,9 @@
 package no.ssb.crypto.tink.fpe;
 
 
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
 import no.ssb.crypto.tink.fpe.util.ByteArrayUtil;
 
 import java.nio.charset.Charset;

--- a/src/main/java/no/ssb/crypto/tink/fpe/FpeWrapper.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/FpeWrapper.java
@@ -16,7 +16,10 @@
 
 package no.ssb.crypto.tink.fpe;
 
-import com.google.crypto.tink.*;
+import com.google.crypto.tink.CryptoFormat;
+import com.google.crypto.tink.PrimitiveSet;
+import com.google.crypto.tink.PrimitiveWrapper;
+import com.google.crypto.tink.Registry;
 import com.google.crypto.tink.internal.MonitoringUtil;
 import com.google.crypto.tink.internal.MutableMonitoringRegistry;
 import com.google.crypto.tink.monitoring.MonitoringClient;

--- a/src/main/java/no/ssb/crypto/tink/fpe/text/CharacterGroup.java
+++ b/src/main/java/no/ssb/crypto/tink/fpe/text/CharacterGroup.java
@@ -138,60 +138,60 @@ public enum CharacterGroup {
 
     /**
      * Default alphanumeric characters
-     * {@code ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789}
+     * {@code 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz}
      */
-    ALPHANUMERIC(LETTERS, DIGITS),
+    ALPHANUMERIC(DIGITS, LETTERS),
 
     /**
      * Default lowercase alphanumeric characters
-     * {@code abcdefghijklmnopqrstuvwxyz0123456789}
+     * {@code 0123456789abcdefghijklmnopqrstuvwxyz}
      */
-    ALPHANUMERIC_LOWERCASE(LETTERS_LOWERCASE, DIGITS),
+    ALPHANUMERIC_LOWERCASE(DIGITS, LETTERS_LOWERCASE),
 
     /**
      * Default lowercase alphanumeric characters
-     * {@code ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789}
+     * {@code 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ}
      */
-    ALPHANUMERIC_UPPERCASE(LETTERS_UPPERCASE, DIGITS),
+    ALPHANUMERIC_UPPERCASE(DIGITS, LETTERS_UPPERCASE),
 
     /**
      * Norwegian alphanumeric characters
-     * {@code ABCDEFGHIJKLMNOPQRSTUVWXYZÅÆØabcdefghijklmnopqrstuvwxyzåæø0123456789}
+     * {@code 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZÅÆØabcdefghijklmnopqrstuvwxyzåæø}
      */
-    ALPHANUMERIC_NO(LETTERS_NO, DIGITS),
+    ALPHANUMERIC_NO(DIGITS, LETTERS_NO),
 
     /**
      * Norwegian lowercase alphanumeric characters
-     * {@code abcdefghijklmnopqrstuvwxyzåæø0123456789}
+     * {@code 0123456789abcdefghijklmnopqrstuvwxyzåæø}
      */
-    ALPHANUMERIC_NO_LOWERCASE(LETTERS_LOWERCASE, LETTERS_EXT_NO_LOWERCASE, DIGITS),
+    ALPHANUMERIC_NO_LOWERCASE(DIGITS, LETTERS_LOWERCASE, LETTERS_EXT_NO_LOWERCASE),
 
     /**
      * Norwegian uppercase alphanumeric characters
-     * {@code ABCDEFGHIJKLMNOPQRSTUVWXYZÅÆØ0123456789}
+     * {@code 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZÅÆØ}
      */
-    ALPHANUMERIC_NO_UPPERCASE(LETTERS_UPPERCASE, LETTERS_EXT_NO_UPPERCASE, DIGITS),
+    ALPHANUMERIC_NO_UPPERCASE(DIGITS, LETTERS_UPPERCASE, LETTERS_EXT_NO_UPPERCASE),
 
     /**
      * All (including extended) alphanumeric characters
-     * {@code ABCDEFGHIJKLMNOPQRSTUVWXYZÅÆØabcdefghijklmnopqrstuvwxyzåæø0123456789}
+     * {@code 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZÅÆØabcdefghijklmnopqrstuvwxyzåæø}
      */
-    ALPHANUMERIC_ALL(LETTERS_ALL, DIGITS),
+    ALPHANUMERIC_ALL(DIGITS, LETTERS_ALL),
 
     /**
      * All alphanumeric lowercase characters (including extended)
-     * {@code abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþß0123456789}
+     * {@code 0123456789abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþß}
      */
-    ALPHANUMERIC_ALL_LOWERCASE(LETTERS_LOWERCASE, LETTERS_EXT_LOWERCASE, DIGITS),
+    ALPHANUMERIC_ALL_LOWERCASE(DIGITS, LETTERS_LOWERCASE, LETTERS_EXT_LOWERCASE),
 
     /**
      * All alphanumeric uppercase characters (including extended)
-     * {@code ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝ0123456789}
+     * {@code 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝ}
      */
-    ALPHANUMERIC_ALL_UPPERCASE(LETTERS_UPPERCASE, LETTERS_EXT_NO_UPPERCASE, DIGITS),
+    ALPHANUMERIC_ALL_UPPERCASE(DIGITS, LETTERS_UPPERCASE, LETTERS_EXT_NO_UPPERCASE),
 
     /**
-     * Any non-control from the basic and exteded latin unicode charset
+     * Any non-control from the basic and extended latin unicode charset
      */
     ANYCHAR(UnicodeChars.stringOf(
       subset(BASIC_LATIN).and(CharType.ALPHANUMERIC),

--- a/src/test/java/no/ssb/crypto/tink/fpe/ByteArrayUtilTest.java
+++ b/src/test/java/no/ssb/crypto/tink/fpe/ByteArrayUtilTest.java
@@ -2,6 +2,8 @@ package no.ssb.crypto.tink.fpe;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static no.ssb.crypto.tink.fpe.util.ByteArrayUtil.b2s;
 import static no.ssb.crypto.tink.fpe.util.ByteArrayUtil.s2b;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,6 +13,8 @@ class ByteArrayUtilTest {
     @Test
     void s2b2s() {
         assertThat(b2s(s2b("Foo æøå"))).isEqualTo("Foo æøå");
+        assertThat(b2s(s2b("Foo æøå", StandardCharsets.UTF_8), StandardCharsets.UTF_8)).isEqualTo("Foo æøå");
+        assertThat(b2s(s2b("Foo æøå", StandardCharsets.ISO_8859_1), StandardCharsets.ISO_8859_1)).isEqualTo("Foo æøå");
     }
 
 }

--- a/src/test/java/no/ssb/crypto/tink/fpe/FpeFf3Test.java
+++ b/src/test/java/no/ssb/crypto/tink/fpe/FpeFf3Test.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FpeFf3Test {
 
-    private final static String KEYSET_JSON_FF31_256_ALPHANUMERIC = "{\"primaryKeyId\":1720617146,\"key\":[{\"keyData\":{\"typeUrl\":\"type.googleapis.com/ssb.crypto.tink.FpeFfxKey\",\"value\":\"EiBoBeUFkoew7YJObcgcz1uOmzdhJFkPP7driAxAuS0UiRpCEAIaPkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5\",\"keyMaterialType\":\"SYMMETRIC\"},\"status\":\"ENABLED\",\"keyId\":1720617146,\"outputPrefixType\":\"RAW\"}]}";
-    private final static String KEYSET_JSON_FF31_192_ALPHANUMERIC = "{\"primaryKeyId\":1928982491,\"key\":[{\"keyData\":{\"typeUrl\":\"type.googleapis.com/ssb.crypto.tink.FpeFfxKey\",\"value\":\"EhizrnA3ckTddEhK3xWtrTMe6MEGpDFGXIUaQhACGj5BQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6MDEyMzQ1Njc4OQ==\",\"keyMaterialType\":\"SYMMETRIC\"},\"status\":\"ENABLED\",\"keyId\":1928982491,\"outputPrefixType\":\"RAW\"}]}";
-    private final static String KEYSET_JSON_FF31_128_ALPHANUMERIC = "{\"primaryKeyId\":1382079328,\"key\":[{\"keyData\":{\"typeUrl\":\"type.googleapis.com/ssb.crypto.tink.FpeFfxKey\",\"value\":\"EhD4978shQNRpBNaBjbF4KO4GkIQAho+QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODk=\",\"keyMaterialType\":\"SYMMETRIC\"},\"status\":\"ENABLED\",\"keyId\":1382079328,\"outputPrefixType\":\"RAW\"}]}";
+    private final static String KEYSET_JSON_FF31_256_ALPHANUMERIC = "{\"primaryKeyId\":832997605,\"key\":[{\"keyData\":{\"typeUrl\":\"type.googleapis.com/ssb.crypto.tink.FpeFfxKey\",\"value\":\"EiCCNkK81HHmUY4IjEzXDrGLOT5t+7PGQ1eIyrGqGa4S3BpCEAIaPjAxMjM0NTY3ODlBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6\",\"keyMaterialType\":\"SYMMETRIC\"},\"status\":\"ENABLED\",\"keyId\":832997605,\"outputPrefixType\":\"RAW\"}]}";
+    private final static String KEYSET_JSON_FF31_192_ALPHANUMERIC = "{\"primaryKeyId\":1472396213,\"key\":[{\"keyData\":{\"typeUrl\":\"type.googleapis.com/ssb.crypto.tink.FpeFfxKey\",\"value\":\"EhjK5UIa3TqJKbcdrnLeGt/9qppevXZJgQ8aQhACGj4wMTIzNDU2Nzg5QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg==\",\"keyMaterialType\":\"SYMMETRIC\"},\"status\":\"ENABLED\",\"keyId\":1472396213,\"outputPrefixType\":\"RAW\"}]}";
+    private final static String KEYSET_JSON_FF31_128_ALPHANUMERIC = "{\"primaryKeyId\":1285197635,\"key\":[{\"keyData\":{\"typeUrl\":\"type.googleapis.com/ssb.crypto.tink.FpeFfxKey\",\"value\":\"EhBiuZBtjIqW+UdSRoGclarMGkIQAho+MDEyMzQ1Njc4OUFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=\",\"keyMaterialType\":\"SYMMETRIC\"},\"status\":\"ENABLED\",\"keyId\":1285197635,\"outputPrefixType\":\"RAW\"}]}";
 
     private final static String longText = "CHAPTER 1. Loomings.\n" +
             "\n" +
@@ -58,7 +58,7 @@ public class FpeFf3Test {
                 .isThrownBy(() -> {
                     fpe.encrypt(s2b(plaintext));
                 })
-                .withMessage("Plaintext can only contain characters from the alphabet 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'");
+                .withMessage("Plaintext can only contain characters from the alphabet '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'");
     }
 
     @Test
@@ -87,16 +87,16 @@ public class FpeFf3Test {
 
     @ParameterizedTest
     @CsvSource(delimiter = ';', value = {
-            "Foobar;6jZemW",
-            "Foo bar;6jZ emW",
-            "If I could gather all the stars and hold them in my hand;Tw 8 Vqp9k FVfYSv DqJ eSe 5nL68 BA8 SkV8 vhX4 Dc SP XImS",
+            "Foobar;b7kOqd",
+            "Foo bar;b7k Oqd",
+            "If I could gather all the stars and hold them in my hand;sr D Gm8se ic4Wid mTd Scz FpVR9 gdn 5dcW 5PCh xD 6C 9GFk",
             "A;A",
             "123;123",
-            "abcd;QCeY",
-            "ab cd;QC eY",
+            "abcd;NcFL",
+            "ab cd;Nc FL",
             "abc#;abc#",
-            "012345678901234567890123456789AB;ULxO2Z2FeOfIpESyrRCBIj2bABCu4sAB",
-            "012345678901234567890123456789#;ULxO2Z2FeOfIpESyrRCBIj2bABCu4s#"
+            "012345678901234567890123456789AB;3wOIPgonKck22IVcL19ti42uFmKM8mAB",
+            "012345678901234567890123456789#;3wOIPgonKck22IVcL19ti42uFmKM8m#"
     })
     void ff31_encrypt_decrypt_alphanumeric_with_skip(String plaintext, String expectedCiphertext) throws Exception {
         KeysetHandle keysetHandle = TinkUtil.readKeyset(KEYSET_JSON_FF31_256_ALPHANUMERIC);
@@ -111,16 +111,16 @@ public class FpeFf3Test {
 
     @ParameterizedTest
     @CsvSource(delimiter = ';', value = {
-            "Foobar;6jZemW;Foobar",
-            "Foo bar;qFejvAC;FooXbar",
-            "If I could gather all the stars and hold them in my hand;qslVtH0Zu2Gcy3I89NeWRwGShILxssNPGM7LABI8wxLcY23UGevd2NaV;IfXIXcouldXgatherXallXtheXstarsXandXholdXthemXinXmyXhand",
+            "Foobar;b7kOqd;Foobar",
+            "Foo bar;EXoaFHU;FooXbar",
+            "If I could gather all the stars and hold them in my hand;t75QqfsrW4ilmkoZzDnBpeyj2il6445WMw63II8UB8kBD5PQESgVng7e;IfXIXcouldXgatherXallXtheXstarsXandXholdXthemXinXmyXhand",
             "A;A;A",
             "123;123;123",
-            "abcd;QCeY;abcd",
-            "ab cd;KtxVK;abXcd",
-            "abc#;SuU6;abcX",
-            "012345678901234567890123456789AB;ULxO2Z2FeOfIpESyrRCBIj2bABCu4sAB;012345678901234567890123456789AB",
-            "012345678901234567890123456789#;ULxO2Z2FeOfIpESyrRCBIj2bABCu4sX;012345678901234567890123456789X"
+            "abcd;NcFL;abcd",
+            "ab cd;kADJO;abXcd",
+            "abc#;tHSF;abcX",
+            "012345678901234567890123456789AB;3wOIPgonKck22IVcL19ti42uFmKM8mAB;012345678901234567890123456789AB",
+            "012345678901234567890123456789#;3wOIPgonKck22IVcL19ti42uFmKM8mX;012345678901234567890123456789X"
     })
     void ff31_encrypt_decrypt_alphanumeric_with_redact(String plaintext, String expectedCiphertext, String expectedPlaintext) throws Exception {
         KeysetHandle keysetHandle = TinkUtil.readKeyset(KEYSET_JSON_FF31_256_ALPHANUMERIC);
@@ -135,16 +135,16 @@ public class FpeFf3Test {
 
     @ParameterizedTest
     @CsvSource(delimiter = ';', value = {
-            "Foobar;6jZemW;Foobar",
-            "Foo bar;6jZemW;Foobar",
-            "If I could gather all the stars and hold them in my hand;Tw8Vqp9kFVfYSvDqJeSe5nL68BA8SkV8vhX4DcSPXImS;IfIcouldgatherallthestarsandholdtheminmyhand",
+            "Foobar;b7kOqd;Foobar",
+            "Foo bar;b7kOqd;Foobar",
+            "If I could gather all the stars and hold them in my hand;srDGm8seic4WidmTdSczFpVR9gdn5dcW5PChxD6C9GFk;IfIcouldgatherallthestarsandholdtheminmyhand",
             "A;A;A",
             "123;123;123",
-            "abcd;QCeY;abcd",
-            "ab cd;QCeY;abcd",
+            "abcd;NcFL;abcd",
+            "ab cd;NcFL;abcd",
             "abc#;abc;abc",
-            "012345678901234567890123456789AB;ULxO2Z2FeOfIpESyrRCBIj2bABCu4sAB;012345678901234567890123456789AB",
-            "012345678901234567890123456789#;ULxO2Z2FeOfIpESyrRCBIj2bABCu4s;012345678901234567890123456789"
+            "012345678901234567890123456789AB;3wOIPgonKck22IVcL19ti42uFmKM8mAB;012345678901234567890123456789AB",
+            "012345678901234567890123456789#;3wOIPgonKck22IVcL19ti42uFmKM8m;012345678901234567890123456789"
     })
     void ff31_encrypt_decrypt_alphanumeric_with_delete(String plaintext, String expectedCiphertext, String expectedPlaintext) throws Exception {
         KeysetHandle keysetHandle = TinkUtil.readKeyset(KEYSET_JSON_FF31_256_ALPHANUMERIC);

--- a/src/test/java/no/ssb/crypto/tink/fpe/MystoTest.java
+++ b/src/test/java/no/ssb/crypto/tink/fpe/MystoTest.java
@@ -1,13 +1,19 @@
 package no.ssb.crypto.tink.fpe;
 
 import com.privacylogistics.FF3Cipher;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MystoTest {
 
     private static final String KEY = "2DE79D232DF5585D68CE47882AE256D6";
     private static final String TWEAK = "CBD09280979564";
-    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final String TWEAK2 = "00000000000000";
+    private static final String ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
     @Test
     void encryptDecrypt() throws Exception {
@@ -20,4 +26,5 @@ public class MystoTest {
         System.out.println("plaintext:  " + plaintext);
         System.out.println("ciphertext: " + ciphertext);
     }
+
 }

--- a/src/test/java/no/ssb/crypto/tink/fpe/MystoTest.java
+++ b/src/test/java/no/ssb/crypto/tink/fpe/MystoTest.java
@@ -1,12 +1,7 @@
 package no.ssb.crypto.tink.fpe;
 
 import com.privacylogistics.FF3Cipher;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.nio.charset.StandardCharsets;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MystoTest {
 

--- a/src/test/java/no/ssb/crypto/tink/fpe/text/CharacterSkipperTest.java
+++ b/src/test/java/no/ssb/crypto/tink/fpe/text/CharacterSkipperTest.java
@@ -1,7 +1,6 @@
 package no.ssb.crypto.tink.fpe.text;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static no.ssb.crypto.tink.fpe.text.CharacterGroup.ALPHANUMERIC;

--- a/src/test/java/no/ssb/crypto/tink/fpe/text/UnicodeCharsTest.java
+++ b/src/test/java/no/ssb/crypto/tink/fpe/text/UnicodeCharsTest.java
@@ -9,8 +9,8 @@ import java.util.stream.Collectors;
 
 import static java.lang.Character.UnicodeBlock.BASIC_LATIN;
 import static java.lang.Character.UnicodeBlock.LATIN_1_SUPPLEMENT;
-import static no.ssb.crypto.tink.fpe.text.UnicodeChars.*;
 import static no.ssb.crypto.tink.fpe.text.UnicodeChars.CharType.*;
+import static no.ssb.crypto.tink.fpe.text.UnicodeChars.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UnicodeCharsTest {


### PR DESCRIPTION
Rearrange default alphanumeric alphabet to align with defaults used by Mysto FPE.

Ref: https://github.com/mysto/java-fpe/issues/9